### PR TITLE
Added additional check for rabbitmq at minemeld startup

### DIFF
--- a/image/services/minemeld/minemeld.runit
+++ b/image/services/minemeld/minemeld.runit
@@ -9,6 +9,10 @@ sv status rabbitmq || exit 1
 sv status redis || exit 1
 sv status collectd || exit 1
 
+echo "minemeld: checking if rabbitmq is serving requests..."
+exec 6<>/dev/tcp/127.0.0.1/5672 || exit 1
+exec 6>&- || exit 1
+
 # check if committed-config exists
 if [ ! -f /opt/minemeld/local/config/committed-config.yml ] ; then
 	mkdir /opt/minemeld/local/prototypes


### PR DESCRIPTION
## Motivation

MineMeld should be started after RabbitMQ is ready to serve requests to avoid early exits from MineMeld. Current checks just check if rabbitmq service has been started but not if it is ready to serve.

## Modifications

Added a new check inside minemeld.runit to double check if the RabbitMQ port is open and ready to serve.

## Result

Improved stability.

Signed-off-by: Luigi Mori <l@isidora.org>